### PR TITLE
Increase K8S storage client timeout settings

### DIFF
--- a/storage/kubernetes/client.go
+++ b/storage/kubernetes/client.go
@@ -298,7 +298,7 @@ func newClient(cluster k8sapi.Cluster, user k8sapi.AuthInfo, namespace string, l
 			KeepAlive: 30 * time.Second,
 		}).Dial,
 		TLSClientConfig:       tlsConfig,
-		TLSHandshakeTimeout:   10 * time.Second,
+		TLSHandshakeTimeout:   20 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 	}
 
@@ -335,7 +335,7 @@ func newClient(cluster k8sapi.Cluster, user k8sapi.AuthInfo, namespace string, l
 	return &client{
 		client: &http.Client{
 			Transport: t,
-			Timeout:   15 * time.Second,
+			Timeout:   35 * time.Second,
 		},
 		baseURL:    cluster.Server,
 		hash:       func() hash.Hash { return fnv.New64() },


### PR DESCRIPTION
In some gardener cluster scenarios where the workers and API server running on a seed cluster are very remote from each other, we observed frequent network connectivity timeouts between the K8S storage client within dex and the kube-apiserver. 

This PR applies an easy workaround by relaxing a few HTTP client timeout parameters so that the dex K8S storage could be less prone to Gardener errors.

Good read: https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/