### PR TITLE
Revert "Increase K8S storage client timeout settings (#14)"

### DIFF
--- a/storage/kubernetes/client.go
+++ b/storage/kubernetes/client.go
@@ -298,7 +298,7 @@ func newClient(cluster k8sapi.Cluster, user k8sapi.AuthInfo, namespace string, l
 			KeepAlive: 30 * time.Second,
 		}).Dial,
 		TLSClientConfig:       tlsConfig,
-		TLSHandshakeTimeout:   20 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 	}
 
@@ -335,7 +335,7 @@ func newClient(cluster k8sapi.Cluster, user k8sapi.AuthInfo, namespace string, l
 	return &client{
 		client: &http.Client{
 			Transport: t,
-			Timeout:   35 * time.Second,
+			Timeout:   15 * time.Second,
 		},
 		baseURL:    cluster.Server,
 		hash:       func() hash.Hash { return fnv.New64() },


### PR DESCRIPTION
This reverts commit 59c6ec8f2aa9fc7a08114fb64e01ce4e7fa4cbf2.
The setting was not a good workaround for the Gardener connectivity problems and hence it is pointless. Instead, another workaround will be applied (configuring liveness probes towards the /healthz endpoint). This will mitigate the broken connectivity (through the Gardener VPN) issue of the HTTP client in dex [which is kept in open state](https://github.com/kyma-incubator/dex/blob/kyma-master/storage/kubernetes/client.go#L152-L157).